### PR TITLE
Support for callout sections

### DIFF
--- a/src/collect.ts
+++ b/src/collect.ts
@@ -160,6 +160,7 @@ class NoteMetricsCollector {
     ["element", UNIT_TOKENIZER],
     ["footnoteDefinition", UNIT_TOKENIZER],
     ["definition", UNIT_TOKENIZER],
+    ["callout", MARKDOWN_TOKENIZER],
   ]);
 
   private vault: Vault;
@@ -183,8 +184,14 @@ class NoteMetricsCollector {
         const startOffset = section.position?.start?.offset;
         const endOffset = section.position?.end?.offset;
         const tokenizer = NoteMetricsCollector.TOKENIZERS.get(sectionType);
-        const tokens = tokenizer.tokenize(content.substring(startOffset, endOffset));
-        return tokens.length;
+        if (!tokenizer) {
+          debugger;
+          console.log(`${file.path}: no tokenizer, section.type=${section.type}`);
+          return 0;
+        } else {
+          const tokens = tokenizer.tokenize(content.substring(startOffset, endOffset));
+          return tokens.length;
+        }
       }).reduce((a, b) => a + b, 0);
     }).catch((e) => {
       console.log(`${file.path} ${e}`);

--- a/src/text.spec.ts
+++ b/src/text.spec.ts
@@ -121,6 +121,13 @@ describe("strip punctuation", () => {
     expect(markdown_tokenize("foo:")).toStrictEqual(["foo"]);
     expect(markdown_tokenize("foo.")).toStrictEqual(["foo"]);
     expect(markdown_tokenize("foo,")).toStrictEqual(["foo"]);
+    expect(markdown_tokenize("foo?")).toStrictEqual(["foo"]);
+    expect(markdown_tokenize("foo!")).toStrictEqual(["foo"]);
+  });
+
+  test("callouts", () => {
+    expect(markdown_tokenize("[!foo]")).toStrictEqual(["foo"]);
+    expect(markdown_tokenize("[!foo bar]")).toStrictEqual(["foo", "bar"]);
   });
 
   test("wiki links", () => {
@@ -235,5 +242,17 @@ blandit nulla. Vivamus id posuere dui.")).
         "posuere",
         "dui",
       ]);
+  });
+
+  test("callouts", () => {
+    expect(markdown_tokenize("> [!Lorem]\
+> Ipsum, dolor sit amet.")).
+    toStrictEqual([
+      "Lorem",
+      "Ipsum",
+      "dolor",
+      "sit",
+      "amet",
+    ]);
   });
 });

--- a/src/text.ts
+++ b/src/text.ts
@@ -45,7 +45,7 @@ class MarkdownTokenizer implements Tokenizer {
   }
 
   private stripPunctuation(token: string): string {
-    const STRIP_PUNCTUATION = /^("|`)?(.*?)(`|\.|:|"|,)?$/;
+    const STRIP_PUNCTUATION = /^(`|\.|:|"|,|!|\?)?(.*?)(`|\.|:|"|,|!|\?)?$/;
     return STRIP_PUNCTUATION.exec(token)[2];
   }
 


### PR DESCRIPTION
`NoteMetricCollector` did not understand sections of type "callout".  This fix adds a tokenizer mapping for callouts as well as some additional unit tests around the callout header syntax.