### PR TITLE
Support Cyrillic symbols

### DIFF
--- a/src/text.ts
+++ b/src/text.ts
@@ -20,7 +20,7 @@ class UnitTokenizer implements Tokenizer {
 class MarkdownTokenizer implements Tokenizer {
 
   private isNonWord(token: string): boolean {
-    const NON_WORDS = /^\W+$/;
+    const NON_WORDS = /^[^\wа-яА-ЯёЁ]+$/;
     return !!NON_WORDS.exec(token);
   }
 


### PR DESCRIPTION
By default regex count only ASCII symbols. This small fix add support for Cyrillic symbols.